### PR TITLE
feat(oAuth2):Added PKCE and checking against CSFR

### DIFF
--- a/app/controllers/auth.controller.go
+++ b/app/controllers/auth.controller.go
@@ -12,8 +12,7 @@ func AuthController(a *fiber.App) {
 
 	route.Get("/google/register", handlers.AuthGoogleGetApprove)
 	route.Get("/google/callback", handlers.Callback)
-	route.Get("/google/login", handlers.AuthGoogleGetApprove)
-
+	route.Get("/google/login", handlers.AuthGoogleGetApprove) //TODO!: Separate login from register. Now when register we login
 	route.Post("/register", handlers.RegisterHandler)
 	route.Post("/login", handlers.LoginHandler)
 	route.Post("/admin_register", middleware.AuthAdmin, handlers.AdminRegisterHandler)

--- a/app/utility/google.util/auth.google.go
+++ b/app/utility/google.util/auth.google.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/grokify/go-pkce"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
@@ -29,13 +30,14 @@ func ConfigGoogle() *oauth2.Config {
 	return conf
 }
 
-func GetTokens(token string) (*GoogleOauthToken, error) {
+func GetTokens(token string, PCKECode string) (*GoogleOauthToken, error) {
 	values := url.Values{}
 	values.Add("grant_type", "authorization_code")
 	values.Add("code", token)
 	values.Add("client_id", os.Getenv("GOOGLE_CLIENT"))
 	values.Add("client_secret", os.Getenv("GOOGLE_SECRET"))
 	values.Add("redirect_uri", os.Getenv("GOOGLE_REDIRECT_URL"))
+	values.Add("code_verifier", PCKECode)
 
 	query := values.Encode()
 
@@ -125,4 +127,15 @@ func GetUserData(tokens *GoogleOauthToken) (*GoogleUserResult, error) {
 	}
 
 	return userBody, nil
+}
+
+func CreatePKCE() *PKCE {
+	NewPKCE := PKCE{
+		pkce.NewCodeVerifier(),
+		""}
+
+	NewPKCE.CodeChallenge = (pkce.CodeChallengeS256(NewPKCE.CodeVerifier))
+
+	ThePKCE = &NewPKCE
+	return ThePKCE
 }

--- a/app/utility/google.util/google.models.go
+++ b/app/utility/google.util/google.models.go
@@ -1,0 +1,28 @@
+package utility
+
+var (
+	ThePKCE *PKCE
+)
+
+type (
+	GoogleOauthToken struct {
+		Access_token string
+		Id_token     string
+	}
+
+	GoogleUserResult struct {
+		Id             string
+		Email          string
+		Verified_email bool
+		Name           string
+		Given_name     string
+		Family_name    string
+		Picture        string
+		Locale         string
+	}
+
+	PKCE struct {
+		CodeVerifier  string
+		CodeChallenge string
+	}
+)

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.2.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/grokify/go-pkce v0.2.0 // indirect
 	github.com/sethvargo/go-password v0.2.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/grokify/go-pkce v0.2.0 h1:IwjppAAUnKZuDo2e3S+EKiwXopAc2UHFzoOFbC24bO0=
+github.com/grokify/go-pkce v0.2.0/go.mod h1:DABMww8Ue+sVrmOBDrt8dH8iFFUtSfmUCKOS3nh4ye8=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=


### PR DESCRIPTION
Сделано:

- Вынес все связанное с oAuth2 Google в подппапку utility. Серега, проверь я там мог напутать с package названием в новой папке.
- Добавил PKCE проверку, чтобы никто не пытался представиться наши приложением.
- Добавил CSRF проверку, потому что так сказали в документации. 
- Добавил возможную TODO для CSFR.

Возник вопросик - а это нормально что у нас если пройти по auth/google/register, то пользователь войдет в кабинет? Надо разносить или оставить? Вроде бы некритично и удобно пользователю, но Андрей может докопаться.
